### PR TITLE
Change email notification to engineering

### DIFF
--- a/dags/daily_user_ingestion.py
+++ b/dags/daily_user_ingestion.py
@@ -15,8 +15,8 @@ default_args = {
     'owner': 'Airflow',
     'depends_on_past': False,
     'start_date': datetime(2019, 12, 5),
-    'email': ['airflow@example.com'],
-    'email_on_failure': False,
+    'email': ['software_engineering@agentiq.com'],
+    'email_on_failure': True,
     'email_on_retry': False,
     'retries': 1,
     'retry_delay': timedelta(minutes=5)}


### PR DESCRIPTION
Change notification to software_engineering@agentiq.com to get failure notification.

is airflow also the same as other services in terms of releases?  @agentiqd @mchow 