### PR TITLE
Add stats configuration as airflow variables

### DIFF
--- a/dags/daily_simple_stats.py
+++ b/dags/daily_simple_stats.py
@@ -35,12 +35,12 @@ env.update({
         'ANALYTICS_DB_HOST': Variable.get('ANALYTICS_DB_HOST'),
         'ANALYTICS_DB_NAME': Variable.get('ANALYTICS_DB_NAME'),
         'ANALYTICS_DB_USERNAME': Variable.get('ANALYTICS_DB_USERNAME'),
-        'ANALYTICS_DB_PASSWORD': Variable.get('ANALYTICS_DB_PASSWORD')},
+        'ANALYTICS_DB_PASSWORD': Variable.get('ANALYTICS_DB_PASSWORD'),
         'STATS_DB_PORT': Variable.get('STATS_DB_PORT'),
         'STATS_DB_HOST': Variable.get('STATS_DB_HOST'),
         'STATS_DB_NAME': Variable.get('STATS_DB_NAME'),
         'STATS_DB_USERNAME': Variable.get('STATS_DB_USERNAME'),
-        'STATS_DB_PASSWORD': Variable.get('STATS_DB_PASSWORD'))
+        'STATS_DB_PASSWORD': Variable.get('STATS_DB_PASSWORD')})
 
 daily_simple_stats = BashOperator(
     task_id='simple_stats_script',

--- a/dags/daily_simple_stats.py
+++ b/dags/daily_simple_stats.py
@@ -35,7 +35,12 @@ env.update({
         'ANALYTICS_DB_HOST': Variable.get('ANALYTICS_DB_HOST'),
         'ANALYTICS_DB_NAME': Variable.get('ANALYTICS_DB_NAME'),
         'ANALYTICS_DB_USERNAME': Variable.get('ANALYTICS_DB_USERNAME'),
-        'ANALYTICS_DB_PASSWORD': Variable.get('ANALYTICS_DB_PASSWORD')})
+        'ANALYTICS_DB_PASSWORD': Variable.get('ANALYTICS_DB_PASSWORD')},
+        'STATS_DB_PORT': Variable.get('STATS_DB_PORT'),
+        'STATS_DB_HOST': Variable.get('STATS_DB_HOST'),
+        'STATS_DB_NAME': Variable.get('STATS_DB_NAME'),
+        'STATS_DB_USERNAME': Variable.get('STATS_DB_USERNAME'),
+        'STATS_DB_PASSWORD': Variable.get('STATS_DB_PASSWORD'))
 
 daily_simple_stats = BashOperator(
     task_id='simple_stats_script',

--- a/variables.json
+++ b/variables.json
@@ -17,6 +17,11 @@
     "ANALYTICS_DB_NAME": "",
     "ANALYTICS_DB_USERNAME": "",
     "ANALYTICS_DB_PASSWORD": "",
+    "STATS_DB_PORT": "",
+    "STATS_DB_HOST": "",
+    "STATS_DB_NAME": "",
+    "STATS_DB_USERNAME": "",
+    "STATS_DB_PASSWORD": "",
     "DOCKER_IMAGE_AI_ENGINE": "",
     "ETL_S3_BUCKET": "agentiq-etl"
 }


### PR DESCRIPTION
Although we have connection to stats through postgres hook, stats variables are needed to run simple stats command.