### PR TITLE
Make airflow customer_events as new dags

### DIFF
--- a/dags/daily_customer_event_metrics.py
+++ b/dags/daily_customer_event_metrics.py
@@ -38,7 +38,7 @@ params = {
     'temp_file_path': '/tmp/customer_events_files/tmp/' + env['ENVIRONMENT'],
     'diff_dir_path': '/tmp/ingestion_diff_dir'}
 
-dag = DAG('customer_event_metrics',
+dag = DAG('daily_customer_event_metrics',
           default_args=default_args,
           # run every day at 3:40am PST after conversation closure
           schedule_interval='40 10 * * 1-7',


### PR DESCRIPTION
It seems there is a bug in airflow that updating tasks instance cause some unique entry error.  Not sure how to resolve this but I believe the name change will create a new dag and deprecate the spoiled dag.

https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-3045?filter=allopenissues

https://stackoverflow.com/questions/52859113/in-apache-airflow-tool-dag-wont-run-due-to-duplicate-entry-problem-in-task-inst