### PR TITLE
change export dag dates, bump pytool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,14 +92,14 @@ RUN apt-get update && \
     gnupg \
     lsb-release
 
-# We should pin docker-ce* (e.g. sudo apt-get install docker-ce=$VERSION docker-ce-cli=$VERSION containerd.io)
-RUN sudo apt-get remove docker docker-engine docker.io containerd runc && \
+# We should pin docker-ce* (e.g. apt-get install docker-ce=$VERSION docker-ce-cli=$VERSION containerd.io)
+RUN apt-get remove docker docker-engine docker.io containerd runc && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-    sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
     echo \
     "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    sudo apt-get install docker-ce docker-ce-cli containerd.io
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get install docker-ce docker-ce-cli containerd.io
 
 
 # Further dependencies should go the below

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get install unzip && cd /tmp && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm awscli-bundle.zip && rm -rf awscli-bundle
  
-RUN curl -fsSL https://get.docker.com | sh
+RUN VERSION=19.03.15 curl -fsSL https://get.docker.com | sh
 
 # Let's start with some basic stuff.
 RUN apt-get install -qqy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # SOURCE: https://github.com/puckel/docker-airflow
 
 #FROM docker:19.03.7-dind
-FROM 036978135238.dkr.ecr.us-east-1.amazonaws.com/agentiq/app-python:3.6-legacy-v3
+FROM 036978135238.dkr.ecr.us-east-1.amazonaws.com/agentiq/app-python:3.8-buster-v1
 
 
 # Never prompts the user for choices on installation/configuration of packages
@@ -79,7 +79,7 @@ RUN apt-get install unzip && cd /tmp && \
     rm awscli-bundle.zip && rm -rf awscli-bundle
  
 # Presently broken
-# RUN curl -fsSL https://get.docker.com | sh
+RUN curl -fsSL https://get.docker.com | sh
 
 # Let's start with some basic stuff.
 RUN apt-get update && \
@@ -92,13 +92,13 @@ RUN apt-get update && \
     gnupg \
     lsb-release
 
-# We should pin docker-ce* (e.g. apt-get install docker-ce=$VERSION docker-ce-cli=$VERSION containerd.io)
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
-    gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
-    echo \
-    "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get install docker-ce docker-ce-cli containerd.io
+# # We should pin docker-ce* (e.g. apt-get install docker-ce=$VERSION docker-ce-cli=$VERSION containerd.io)
+# RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+#     gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+#     echo \
+#     "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+#     $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+#     apt-get install docker-ce docker-ce-cli containerd.io
 
 
 # Further dependencies should go the below

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,8 +93,7 @@ RUN apt-get update && \
     lsb-release
 
 # We should pin docker-ce* (e.g. apt-get install docker-ce=$VERSION docker-ce-cli=$VERSION containerd.io)
-RUN apt-get remove docker docker-engine docker.io containerd runc && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
     gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
     echo \
     "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # SOURCE: https://github.com/puckel/docker-airflow
 
 #FROM docker:19.03.7-dind
-FROM 036978135238.dkr.ecr.us-east-1.amazonaws.com/agentiq/app-python:3.8-buster-v1
+FROM 036978135238.dkr.ecr.us-east-1.amazonaws.com/agentiq/app-python:3.6-buster-v1
 
 
 # Never prompts the user for choices on installation/configuration of packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get install unzip && cd /tmp && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm awscli-bundle.zip && rm -rf awscli-bundle
  
-RUN curl -sSL https://get.docker.com/ | sh
+RUN curl -fsSL https://get.docker.com | sh
 
 # Let's start with some basic stuff.
 RUN apt-get install -qqy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ RUN apt-get install unzip && cd /tmp && \
     ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm awscli-bundle.zip && rm -rf awscli-bundle
  
-RUN VERSION=19.03.15 curl -fsSL https://get.docker.com | sh
+# Presently broken
+# RUN curl -fsSL https://get.docker.com | sh
 
 # Let's start with some basic stuff.
 RUN apt-get install -qqy \
@@ -86,7 +87,19 @@ RUN apt-get install -qqy \
     ca-certificates \
     curl \
     lxc \
-    iptables
+    iptables \
+    gnupg \
+    lsb-release
+
+# We should pin docker-ce* (e.g. sudo apt-get install docker-ce=$VERSION docker-ce-cli=$VERSION containerd.io)
+RUN sudo apt-get remove docker docker-engine docker.io containerd runc && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+    sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo \
+    "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    sudo apt-get install docker-ce docker-ce-cli containerd.io
+
 
 # Further dependencies should go the below
 RUN apt-get install -qqy \

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,8 @@ RUN apt-get install unzip && cd /tmp && \
 # RUN curl -fsSL https://get.docker.com | sh
 
 # Let's start with some basic stuff.
-RUN apt-get install -qqy \
+RUN apt-get update && \
+    apt-get install -qqy \
     apt-transport-https \
     ca-certificates \
     curl \

--- a/dags/daily_data_export.py
+++ b/dags/daily_data_export.py
@@ -31,8 +31,13 @@ dag = DAG('daily_data_export',
 
 def get_start_end_time(execution_date):
     # time might need to fine control again
-    return (execution_date.subtract(days=1).format("%Y-%m-%d %H:%M:%S"),
-            execution_date.format("%Y-%m-%d %H:%M:%S"))
+    # scheduled day = execution day = trigger day - 1,
+    # airflow execution date is not trigger/ran date
+    # it is date on which task is scheduled to run
+    # and actual run happens one schedule_interval after scheduled date
+    # https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html
+    return (execution_date.format("%Y-%m-%d %H:%M:%S"),
+            execution_date.add(days=1).format("%Y-%m-%d %H:%M:%S"))
 
 
 def run_export(*args, **kwargs):


### PR DESCRIPTION
## Description of the change
Addressing the following from Ali at pnb
" There seems to be a minimum 36 hour gap between when a user is created in ParkDirect and when they are retrieved through the API."

> Description here
![Screen Shot 2021-04-28 at 12 09 14 PM](https://user-images.githubusercontent.com/4338390/116488815-2feb6600-a848-11eb-9bcc-c6656d6d8f6c.png)
![Screen Shot 2021-04-28 at 12 09 54 PM](https://user-images.githubusercontent.com/4338390/116488817-31b52980-a848-11eb-8e67-474f44a20be2.png)


scheduled day = execution day = trigger day - 1, therefore when scheduled for 27/04  10:00 , it ran on 28/04 10:00

which explains
*** Reading local file: /usr/local/airflow/logs/daily_data_export/run_export/2021-04-27T10:10:00+00:00/1.log
[2021-04-28 10:10:06,894] {{taskinstance.py:655}} INFO - Dependencies all met for <TaskInstance: daily_data_export.run_export 2021-04-27T10:10:00+00:00 [queued]>
[2021-04-28 10:10:06,920] {{taskinstance.py:655}} INFO - Dependencies all met for <TaskInstance: daily_data_export.run_export 2021-04-27T10:10:00+00:00 [queued]>
[2021-04-28 10:10:06,920] {{taskinstance.py:866}} INFO ***

from
pnb dag logs
This consequently pulled data from 4/26 to 4/27

Apache docs also say the following
```
Let's Repeat That, the scheduler runs your job one schedule_interval AFTER the start date, at the END of the period
```
here https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html


here is a more detailed example
https://towardsdatascience.com/apache-airflow-tips-and-best-practices-ff64ce92ef8

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 

