### PR TITLE
use airflow var for remote and bump pytool

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ airflow list_dags
     export AIRFLOW_HOME={path to you airflow repo}
     if
         PYTHONPATH is empty , do
-        export PYTHONPATH="$AIQ_AIRFLOW_HOME/python-tools:$AIQ_AIRFLOW_HOME/aiq-dynamo-python"
+        export PYTHONPATH="$AIRFLOW_HOME/python-tools:$AIRFLOW_HOME/aiq-dynamo-python"
     otherwise, do:
-        export PYTHONPATH="$PYTHONPATH:$AIQ_AIRFLOW_HOME/python-tools:$AIQ_AIRFLOW_HOME/aiq-dynamo-python"
+        export PYTHONPATH="$PYTHONPATH:$AIRFLOW_HOME/python-tools:$AIRFLOW_HOME/aiq-dynamo-python"
   
   ```
 -   install requirements from python tools and aiq-dynamo sub modules
@@ -70,7 +70,7 @@ airflow list_dags
     ```
     airflow variables -i vars.json
     ```
-- initialize airflow DB  ```airflow initdb```
+- initialize airflow DB  ```airflow db init```
 - run airflow server ```airflow webserver -p 8080```
 - run airflow scheduler ```airflow scheduler```
   If the scheduler gets stuck resetting old DAG runs, old DAGs could be deleted

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ airflow list_dags
   python modules and without it, DAGs cannot access submodules. Set it up
   as follows
   ```
-    export AIQ_AIRFLOW_HOME={path to you airflow repo}
+    export AIRFLOW_HOME={path to you airflow repo}
     if
         PYTHONPATH is empty , do
         export PYTHONPATH="$AIQ_AIRFLOW_HOME/python-tools:$AIQ_AIRFLOW_HOME/aiq-dynamo-python"

--- a/dags/backfill_simple_stats.py
+++ b/dags/backfill_simple_stats.py
@@ -52,7 +52,7 @@ env.update(get_environments())
 
 backfill_simple_stats = BashOperator(
     task_id='simple_stats_backfill_script',
-    bash_command="${AIQ_AIRFLOW_HOME}/python-tools/scripts/backfill_simple_stats.sh \
+    bash_command="${AIRFLOW_HOME}/python-tools/scripts/backfill_simple_stats.sh \
 {{ dag_run.conf['start_date'] }} {{ dag_run.conf['end_date'] }} ",
     retries=1,
     schedule_interval=None,


### PR DESCRIPTION
![Screen Shot 2021-11-17 at 11 12 40 AM](https://user-images.githubusercontent.com/4338390/142267873-e3588312-9ebf-4fa9-9c12-adea93089dc3.png)
DEMO4 is now using AIRFLOW_HOME

it was working locally with AIQ_AIRFLOW_HOME for demo4 as can be seen in screen shots here
https://github.com/AgentIQ/aiq-airflow/pull/272

@agentiqd 