### PR TITLE
Changed to PythonOperator for easier templating.

### DIFF
--- a/dags/collab_metrics.py
+++ b/dags/collab_metrics.py
@@ -16,7 +16,8 @@ collect and organize collab events.
 
 """
 import os
-from airflow import DAG, task
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
 from datetime import datetime, timedelta
 from utils.email_helper import email_notify
 from tools.analysis.collab_metrics.collab_metrics import CollabMetrics
@@ -56,27 +57,12 @@ cur = stats_conn.cursor()
 params = {"cursor": cur}
 
 
-@task(
-    task_id="extract_collab_events",
-    templates_dict={
-        "logical_date": "{{ ds }}",
-        "day_before": "{{ macros.ds_add(ds, -1) }}",
-    },
-)
 def extract_collab_events(*args, **kwargs):
     start_time = kwargs["templates_dict"]["day_before"]
     end_time = kwargs["templates_dict"]["logical_date"]
     CollabETL.extract_messages(start_time, end_time)
 
 
-@task(
-    task_id="load_collab_events",
-    templates_dict={
-        "logical_date": "{{ ds }}",
-        "day_before": "{{ macros.ds_add(ds, -1) }}",
-        "cursor": cur,
-    },
-)
 def load_collab_events(*args, **kwargs):
     cursor = kwargs["templates_dict"]["cursor"]
     CollabETL.load_messages(cursor, CollabETL.transform_message())
@@ -84,10 +70,35 @@ def load_collab_events(*args, **kwargs):
     stats_conn.commit()
 
 
-@task(task_id="close_stats_conn")
 def close_stats_conn(*args, **kwargs):
     stats_conn.commit()
     stats_conn.close()
+
+
+extract_collab_events = PythonOperator(
+    task_id="extract_collab_events",
+    python_callable=extract_collab_events,
+    templates_dict={
+        "logical_date": "{{ ds }}",
+        "day_before": "{{ macros.ds_add(ds, -1) }}",
+    },
+    dag=dag)
+
+
+load_collab_events = PythonOperator(
+    task_id="load_collab_events",
+    python_callable=load_collab_events,
+    templates_dict={
+        "logical_date": "{{ ds }}",
+        "day_before": "{{ macros.ds_add(ds, -1) }}",
+        "cursor": cur,
+    },
+    dag=dag)
+
+close_stats_conn = PythonOperator(
+    task_id='close_stats_conn',
+    python_callable=close_stats_conn,
+    dag=dag)
 
 
 extract_collab_events >> load_collab_events >> close_stats_conn


### PR DESCRIPTION
## Description of the change

Updated DAG tasks to use older PythonOperator instead of task decorator, to keep templating cleaner based on airflow best practices.

